### PR TITLE
Added question mark after 'Are those your friends'

### DIFF
--- a/src/epub/text/the-adventure-of-the-cheap-flat.xhtml
+++ b/src/epub/text/the-adventure-of-the-cheap-flat.xhtml
@@ -95,7 +95,7 @@
 			<p>“That you will need it? It is quite possible. The idea pleases you, I see. Always the spectacular and romantic appeals to you.”</p>
 			<p>The following day saw us installed in our temporary home. The flat was pleasantly furnished. It occupied the same position in the building as that of the Robinsons, but was two floors higher.</p>
 			<p>The day after our installation was a Sunday. In the afternoon, Poirot left the front door ajar, and summoned me hastily as a bang reverberated from somewhere below.</p>
-			<p>“Look over the banisters. Are those your friends. Do not let them see you.”</p>
+			<p>“Look over the banisters. Are those your friends? Do not let them see you.”</p>
 			<p>I craned my neck over the staircase.</p>
 			<p>“That’s them,” I declared in an ungrammatical whisper.</p>
 			<p>“Good. Wait awhile.”</p>


### PR DESCRIPTION
In the [scans used by PG](https://archive.org/details/poirotinv00agch_images/page/n85/mode/2up), this typo is present, but [in a different set of scans](https://archive.org/details/in.ernet.dli.2015.148803/page/n53/mode/2up), the period is replaced with a question mark, which reads better to me.